### PR TITLE
Revert "Update liberty runtime version to 19008"

### DIFF
--- a/boost-maven/boost-runtimes/runtime-openliberty/src/main/java/boost/runtimes/openliberty/LibertyRuntime.java
+++ b/boost-maven/boost-runtimes/runtime-openliberty/src/main/java/boost/runtimes/openliberty/LibertyRuntime.java
@@ -56,7 +56,7 @@ public class LibertyRuntime implements RuntimeI {
 
     private final String runtimeGroupId = "io.openliberty";
     private final String runtimeArtifactId = "openliberty-runtime";
-    private final String runtimeVersion = "19.0.0.8";
+    private final String runtimeVersion = "19.0.0.3";
 
     private String libertyMavenPluginGroupId = "io.openliberty.tools";
     private String libertyMavenPluginArtifactId = "liberty-maven-plugin";


### PR DESCRIPTION
Reverts MicroShed/boost#365

Caused problems like:

`[INFO] [ERROR] Failed to execute goal boost:boost-maven-plugin:0.1.3-SNAPSHOT:package (default) on project microprofile-health: Error performing server package: Error packaging Liberty server: Unable to execute mojo: The jar packageType requires `all` or `minify` in the `include` parameter -> [Help 1]`

Not sure what happened with Travis.. if it didn't run or if we just missed the fact that it failed.