### PR TITLE
New microshed gid

### DIFF
--- a/boost-common/pom.xml
+++ b/boost-common/pom.xml
@@ -8,7 +8,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost</groupId>
+    <groupId>org.microshed.boost</groupId>
     <artifactId>boost-common</artifactId>
     <version>1.0-M1-SNAPSHOT</version>
 

--- a/boost-common/pom.xml
+++ b/boost-common/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>org.microshed.boost</groupId>
     <artifactId>boost-common</artifactId>
-    <version>1.0-M1-SNAPSHOT</version>
+    <version>0.2</version>
 
     <url>https://github.com/OpenLiberty/boost</url>
 

--- a/boost-common/pom.xml
+++ b/boost-common/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>boost</groupId>
     <artifactId>boost-common</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>1.0-M1-SNAPSHOT</version>
 
     <url>https://github.com/OpenLiberty/boost</url>
 

--- a/boost-common/src/main/java/boost/common/boosters/AbstractBoosterConfig.java
+++ b/boost-common/src/main/java/boost/common/boosters/AbstractBoosterConfig.java
@@ -31,8 +31,8 @@ public abstract class AbstractBoosterConfig {
     // <Major>.<Minor>-<boost version>-<Milestone>[-SNAPSHOT]
     public static final String milestone = "M1";
     public static final String boostVersion = "1.0";
-    public static final String RUNTIMES_GROUP_ID = "boost.runtimes";
-    public static final String BOOSTERS_GROUP_ID = "boost.boosters";
+    public static final String RUNTIMES_GROUP_ID = "org.microshed.boost.runtimes";
+    public static final String BOOSTERS_GROUP_ID = "org.microshed.boost.boosters";
     public static final String CDI_VERSION_12 = "1.2-" + boostVersion + "-" + milestone + "-SNAPSHOT";
     public static final String CDI_VERSION_20 = "2.0-" + boostVersion + "-" + milestone + "-SNAPSHOT";
     public static final String JAXRS_VERSION_20 = "2.0-" + boostVersion + "-" + milestone + "-SNAPSHOT";

--- a/boost-gradle/README.md
+++ b/boost-gradle/README.md
@@ -23,7 +23,7 @@ buildscript {
         mavenLocal()
     }
     dependencies {
-        classpath 'io.openliberty.boost:boost-gradle-plugin:0.1-SNAPSHOT'
+        classpath 'io.openliberty.boost:boost-gradle-plugin:1.0-M1-SNAPSHOT'
     }
 }
 

--- a/boost-gradle/build.gradle
+++ b/boost-gradle/build.gradle
@@ -9,7 +9,7 @@ archivesBaseName = 'boost-gradle-plugin'
 group = 'io.openliberty.boost'
 version = '0.1.1-SNAPSHOT'
 
-def boosterVersion = '0.1.3-SNAPSHOT'
+def boosterVersion = '1.0-M1-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -26,7 +26,7 @@ dependencies {
     compile localGroovy()
     compile 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.6.6-SNAPSHOT'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
-    compile 'io.openliberty.boost:boost-common:0.1.3-SNAPSHOT'
+    compile 'io.openliberty.boost:boost-common:1.0-M1-SNAPSHOT'
     compile 'com.spotify:docker-client:8.11.7'
 
     testCompile 'junit:junit:4.12'

--- a/boost-maven/README.md
+++ b/boost-maven/README.md
@@ -23,7 +23,7 @@ Edit your project pom.xml and place the following plugin stanza into your build:
 <plugin>
 	<groupId>boost</groupId>
 	<artifactId>boost-maven-plugin</artifactId>
-	<version>0.1.3-SNAPSHOT</version>
+	<version>1.0-M1-SNAPSHOT</version>
 	<executions>
 		<execution>
 			<goals>

--- a/boost-maven/README.md
+++ b/boost-maven/README.md
@@ -23,7 +23,7 @@ Edit your project pom.xml and place the following plugin stanza into your build:
 <plugin>
 	<groupId>org.microshed.boost</groupId>
 	<artifactId>boost-maven-plugin</artifactId>
-	<version>1.0-M1-SNAPSHOT</version>
+	<version>0.2</version>
 	<executions>
 		<execution>
 			<goals>

--- a/boost-maven/README.md
+++ b/boost-maven/README.md
@@ -21,7 +21,7 @@ When added to your pom.xml, the plugin will
 Edit your project pom.xml and place the following plugin stanza into your build:
 ```xml
 <plugin>
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>boost-maven-plugin</artifactId>
 	<version>1.0-M1-SNAPSHOT</version>
 	<executions>

--- a/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
@@ -9,7 +9,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boosters</groupId>
+	<groupId>boost.boms</groupId>
 	<artifactId>boost-ee7-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>boost.boosters</groupId>
 	<artifactId>boost-ee7-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>0.1-SNAPSHOT</version>
+	<version>1.0-M1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<description>Boost EE7 APIs BOM</description>

--- a/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-ee7-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>1.0-M1-SNAPSHOT</version>
+	<version>0.2</version>
 	<packaging>pom</packaging>
 
 	<description>Boost EE7 APIs BOM</description>

--- a/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee7-apis-bom/pom.xml
@@ -9,7 +9,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boms</groupId>
+	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-ee7-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
@@ -8,7 +8,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>boost.boms</groupId>
     <artifactId>boost-ee8-apis-bom</artifactId>
     <!-- Versioned separately from the main project -->
     <version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
@@ -11,7 +11,7 @@
     <groupId>boost.boosters</groupId>
     <artifactId>boost-ee8-apis-bom</artifactId>
     <!-- Versioned separately from the main project -->
-    <version>0.1-SNAPSHOT</version>
+    <version>1.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <description>Boost EE8 APIs BOM</description>

--- a/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
@@ -8,7 +8,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boms</groupId>
+    <groupId>org.microshed.boost.boms</groupId>
     <artifactId>boost-ee8-apis-bom</artifactId>
     <!-- Versioned separately from the main project -->
     <version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-ee8-apis-bom/pom.xml
@@ -11,7 +11,7 @@
     <groupId>org.microshed.boost.boms</groupId>
     <artifactId>boost-ee8-apis-bom</artifactId>
     <!-- Versioned separately from the main project -->
-    <version>1.0-M1-SNAPSHOT</version>
+    <version>0.2</version>
     <packaging>pom</packaging>
 
     <description>Boost EE8 APIs BOM</description>

--- a/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
@@ -16,29 +16,8 @@
 
 	<description>Booster MP14 APIs Bom</description>
 
-	<properties>
-
-		<!-- MicroProfile 1.4 specs -->
-		<config-version>1.3</config-version>
-		<ft-version>1.1</ft-version>
-		<health-version>1.0</health-version>
-		<metrics-version>1.1</metrics-version>
-		<jwt-version>1.1</jwt-version>
-		<openapi-version>1.0</openapi-version>
-		<rest-client-version>1.1</rest-client-version>
-		<opentracing-version>1.1</opentracing-version>
-
-	</properties>
-
 	<dependencyManagement>
 		<dependencies>
-			<!--
-			<dependency>
-				<groupId>boost.boosters</groupId>
-				<artifactId>boost-ee8-apis-bom</artifactId>
-				<version>1.0-M1-SNAPSHOT</version>
-			</dependency>
-			-->
 			<dependency>
     			<groupId>org.eclipse.microprofile</groupId>
     			<artifactId>microprofile</artifactId>
@@ -46,48 +25,6 @@
 				<type>pom</type>
     			<scope>import</scope>
 			</dependency>
-			<!--
-			<dependency>
-				<groupId>org.eclipse.microprofile.config</groupId>
-				<artifactId>microprofile-config-api</artifactId>
-				<version>${config-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.fault-tolerance</groupId>
-				<artifactId>microprofile-fault-tolerance-api</artifactId>
-				<version>${ft-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.health</groupId>
-				<artifactId>microprofile-health-api</artifactId>
-				<version>${health-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.metrics</groupId>
-				<artifactId>microprofile-metrics-api</artifactId>
-				<version>${metrics-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.jwt</groupId>
-				<artifactId>microprofile-jwt-auth-api</artifactId>
-				<version>${jwt-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.openapi</groupId>
-				<artifactId>microprofile-openapi-api</artifactId>
-				<version>${openapi-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.rest.client</groupId>
-				<artifactId>microprofile-rest-client-api</artifactId>
-				<version>${rest-client-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.opentracing</groupId>
-				<artifactId>microprofile-opentracing-api</artifactId>
-				<version>${opentracing-version}</version>
-			</dependency>
-			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boms</groupId>
+	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp14-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boosters</groupId>
+	<groupId>boost.boms</groupId>
 	<artifactId>boost-mp14-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>boost.boosters</groupId>
 	<artifactId>boost-mp14-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>0.1-SNAPSHOT</version>
+	<version>1.0-M1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP14 APIs Bom</description>
@@ -32,11 +32,21 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<!--
 			<dependency>
 				<groupId>boost.boosters</groupId>
 				<artifactId>boost-ee8-apis-bom</artifactId>
-				<version>0.1-SNAPSHOT</version>
+				<version>1.0-M1-SNAPSHOT</version>
 			</dependency>
+			-->
+			<dependency>
+    			<groupId>org.eclipse.microprofile</groupId>
+    			<artifactId>microprofile</artifactId>
+    			<version>1.4</version>
+				<type>pom</type>
+    			<scope>import</scope>
+			</dependency>
+			<!--
 			<dependency>
 				<groupId>org.eclipse.microprofile.config</groupId>
 				<artifactId>microprofile-config-api</artifactId>
@@ -77,6 +87,7 @@
 				<artifactId>microprofile-opentracing-api</artifactId>
 				<version>${opentracing-version}</version>
 			</dependency>
+			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp14-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp14-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>1.0-M1-SNAPSHOT</version>
+	<version>0.2</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP14 APIs Bom</description>

--- a/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>boost.boosters</groupId>
 	<artifactId>boost-mp20-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>0.1-SNAPSHOT</version>
+	<version>1.0-M1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP20 APIs Bom</description>
@@ -32,11 +32,21 @@
 
 	<dependencyManagement>
 		<dependencies>
+		<!--
 			<dependency>
 				<groupId>boost.boosters</groupId>
 				<artifactId>boost-ee8-apis-bom</artifactId>
-				<version>0.1-SNAPSHOT</version>
+				<version>1.0-M1-SNAPSHOT</version>
 			</dependency>
+			-->
+			<dependency>
+    			<groupId>org.eclipse.microprofile</groupId>
+    			<artifactId>microprofile</artifactId>
+    			<version>2.0</version>
+				<type>pom</type>
+    			<scope>import</scope>
+			</dependency>
+			<!--
 			<dependency>
 				<groupId>org.eclipse.microprofile.config</groupId>
 				<artifactId>microprofile-config-api</artifactId>
@@ -77,6 +87,7 @@
 				<artifactId>microprofile-opentracing-api</artifactId>
 				<version>${opentracing-version}</version>
 			</dependency>
+			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp20-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>1.0-M1-SNAPSHOT</version>
+	<version>0.2</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP20 APIs Bom</description>

--- a/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
@@ -16,29 +16,8 @@
 
 	<description>Booster MP20 APIs Bom</description>
 
-	<properties>
-
-		<!-- MicroProfile 2.0 specs -->
-		<config-version>1.3</config-version>
-		<ft-version>1.1</ft-version>
-		<health-version>1.0</health-version>
-		<metrics-version>1.1</metrics-version>
-		<jwt-version>1.1</jwt-version>
-		<openapi-version>1.0</openapi-version>
-		<rest-client-version>1.1</rest-client-version>
-		<opentracing-version>1.1</opentracing-version>
-
-	</properties>
-
 	<dependencyManagement>
 		<dependencies>
-		<!--
-			<dependency>
-				<groupId>boost.boosters</groupId>
-				<artifactId>boost-ee8-apis-bom</artifactId>
-				<version>1.0-M1-SNAPSHOT</version>
-			</dependency>
-			-->
 			<dependency>
     			<groupId>org.eclipse.microprofile</groupId>
     			<artifactId>microprofile</artifactId>
@@ -46,48 +25,6 @@
 				<type>pom</type>
     			<scope>import</scope>
 			</dependency>
-			<!--
-			<dependency>
-				<groupId>org.eclipse.microprofile.config</groupId>
-				<artifactId>microprofile-config-api</artifactId>
-				<version>${config-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.fault-tolerance</groupId>
-				<artifactId>microprofile-fault-tolerance-api</artifactId>
-				<version>${ft-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.health</groupId>
-				<artifactId>microprofile-health-api</artifactId>
-				<version>${health-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.metrics</groupId>
-				<artifactId>microprofile-metrics-api</artifactId>
-				<version>${metrics-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.jwt</groupId>
-				<artifactId>microprofile-jwt-auth-api</artifactId>
-				<version>${jwt-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.openapi</groupId>
-				<artifactId>microprofile-openapi-api</artifactId>
-				<version>${openapi-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.rest.client</groupId>
-				<artifactId>microprofile-rest-client-api</artifactId>
-				<version>${rest-client-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.opentracing</groupId>
-				<artifactId>microprofile-opentracing-api</artifactId>
-				<version>${opentracing-version}</version>
-			</dependency>
-			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boosters</groupId>
+	<groupId>boost.boms</groupId>
 	<artifactId>boost-mp20-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp20-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boms</groupId>
+	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp20-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp21-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>1.0-M1-SNAPSHOT</version>
+	<version>0.2</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP21 APIs Bom</description>

--- a/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boms</groupId>
+	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp21-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boosters</groupId>
+	<groupId>boost.boms</groupId>
 	<artifactId>boost-mp21-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>boost.boosters</groupId>
 	<artifactId>boost-mp21-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>0.1-SNAPSHOT</version>
+	<version>1.0-M1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP21 APIs Bom</description>
@@ -31,11 +31,21 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<!--
 			<dependency>
 				<groupId>boost.boosters</groupId>
 				<artifactId>boost-ee8-apis-bom</artifactId>
-				<version>0.1-SNAPSHOT</version>
+				<version>1.0-M1-SNAPSHOT</version>
 			</dependency>
+			-->
+			<dependency>
+    			<groupId>org.eclipse.microprofile</groupId>
+    			<artifactId>microprofile</artifactId>
+    			<version>2.1</version>
+				<type>pom</type>
+    			<scope>import</scope>
+			</dependency>
+			<!--
 			<dependency>
 				<groupId>org.eclipse.microprofile.config</groupId>
 				<artifactId>microprofile-config-api</artifactId>
@@ -76,6 +86,7 @@
 				<artifactId>microprofile-opentracing-api</artifactId>
 				<version>${opentracing-version}</version>
 			</dependency>
+			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp21-apis-bom/pom.xml
@@ -16,28 +16,8 @@
 
 	<description>Booster MP21 APIs Bom</description>
 
-	<properties>
-		<!-- MicroProfile 2.1 specs -->
-		<config-version>1.3</config-version>
-		<ft-version>1.1</ft-version>
-		<health-version>1.0</health-version>
-		<metrics-version>1.1</metrics-version>
-		<jwt-version>1.1</jwt-version>
-		<openapi-version>1.0</openapi-version>
-		<rest-client-version>1.1</rest-client-version>
-		<opentracing-version>1.2</opentracing-version>
-
-	</properties>
-
 	<dependencyManagement>
 		<dependencies>
-			<!--
-			<dependency>
-				<groupId>boost.boosters</groupId>
-				<artifactId>boost-ee8-apis-bom</artifactId>
-				<version>1.0-M1-SNAPSHOT</version>
-			</dependency>
-			-->
 			<dependency>
     			<groupId>org.eclipse.microprofile</groupId>
     			<artifactId>microprofile</artifactId>
@@ -45,48 +25,6 @@
 				<type>pom</type>
     			<scope>import</scope>
 			</dependency>
-			<!--
-			<dependency>
-				<groupId>org.eclipse.microprofile.config</groupId>
-				<artifactId>microprofile-config-api</artifactId>
-				<version>${config-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.fault-tolerance</groupId>
-				<artifactId>microprofile-fault-tolerance-api</artifactId>
-				<version>${ft-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.health</groupId>
-				<artifactId>microprofile-health-api</artifactId>
-				<version>${health-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.metrics</groupId>
-				<artifactId>microprofile-metrics-api</artifactId>
-				<version>${metrics-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.jwt</groupId>
-				<artifactId>microprofile-jwt-auth-api</artifactId>
-				<version>${jwt-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.openapi</groupId>
-				<artifactId>microprofile-openapi-api</artifactId>
-				<version>${openapi-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.rest.client</groupId>
-				<artifactId>microprofile-rest-client-api</artifactId>
-				<version>${rest-client-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.opentracing</groupId>
-				<artifactId>microprofile-opentracing-api</artifactId>
-				<version>${opentracing-version}</version>
-			</dependency>
-			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
@@ -16,26 +16,6 @@
 
 	<description>Booster MP22 APIs Bom</description>
 
-	<properties>
-		<!-- Java EE specs -->
-		<cdi-version>2.0</cdi-version>
-		<jaxrs-version>2.1</jaxrs-version>
-		<jsonp-version>1.1</jsonp-version>
-		<jsonb-version>1.0</jsonb-version>
-		<annotation-version>1.2</annotation-version>
-
-		<!-- MicroProfile specs -->
-		<config-version>1.3</config-version>
-		<ft-version>2.0</ft-version>
-		<health-version>1.0</health-version>
-		<metrics-version>1.1</metrics-version>
-		<jwt-version>1.1</jwt-version>
-		<openapi-version>1.1</openapi-version>
-		<rest-client-version>1.2</rest-client-version>
-		<opentracing-version>1.3</opentracing-version>
-
-	</properties>
-
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -45,68 +25,6 @@
 				<type>pom</type>
     			<scope>import</scope>
 			</dependency>
-			<!--
-			<dependency>
-				<groupId>javax.enterprise</groupId>
-				<artifactId>cdi-api</artifactId>
-				<version>${cdi-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.ws.rs</groupId>
-				<artifactId>javax.ws.rs-api</artifactId>
-				<version>${jaxrs-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.json</groupId>
-				<artifactId>javax.json-api</artifactId>
-				<version>${jsonp-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>javax.annotation</groupId>
-				<artifactId>javax.annotation-api</artifactId>
-				<version>${annotation-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.config</groupId>
-				<artifactId>microprofile-config-api</artifactId>
-				<version>${config-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.fault-tolerance</groupId>
-				<artifactId>microprofile-fault-tolerance-api</artifactId>
-				<version>${ft-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.health</groupId>
-				<artifactId>microprofile-health-api</artifactId>
-				<version>${health-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.metrics</groupId>
-				<artifactId>microprofile-metrics-api</artifactId>
-				<version>${metrics-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.jwt</groupId>
-				<artifactId>microprofile-jwt-auth-api</artifactId>
-				<version>${jwt-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.openapi</groupId>
-				<artifactId>microprofile-openapi-api</artifactId>
-				<version>${openapi-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.rest.client</groupId>
-				<artifactId>microprofile-rest-client-api</artifactId>
-				<version>${rest-client-version}</version>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.microprofile.opentracing</groupId>
-				<artifactId>microprofile-opentracing-api</artifactId>
-				<version>${opentracing-version}</version>
-			</dependency>
-			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boosters</groupId>
+	<groupId>boost.boms</groupId>
 	<artifactId>boost-mp22-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp22-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>1.0-M1-SNAPSHOT</version>
+	<version>0.2</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP22 APIs Bom</description>

--- a/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>boost.boosters</groupId>
 	<artifactId>boost-mp22-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
-	<version>0.1-SNAPSHOT</version>
+	<version>1.0-M1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<description>Booster MP22 APIs Bom</description>
@@ -38,6 +38,14 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+    			<groupId>org.eclipse.microprofile</groupId>
+    			<artifactId>microprofile</artifactId>
+    			<version>2.2</version>
+				<type>pom</type>
+    			<scope>import</scope>
+			</dependency>
+			<!--
 			<dependency>
 				<groupId>javax.enterprise</groupId>
 				<artifactId>cdi-api</artifactId>
@@ -98,6 +106,7 @@
 				<artifactId>microprofile-opentracing-api</artifactId>
 				<version>${opentracing-version}</version>
 			</dependency>
+			-->
 		</dependencies>
 	</dependencyManagement>
 

--- a/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
+++ b/boost-maven/boost-boms/boost-mp22-apis-bom/pom.xml
@@ -8,7 +8,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.boms</groupId>
+	<groupId>org.microshed.boost.boms</groupId>
 	<artifactId>boost-mp22-apis-bom</artifactId>
 	<!-- Versioned separately from the main project -->
 	<version>1.0-M1-SNAPSHOT</version>

--- a/boost-maven/boost-boms/booster-ee7-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee7-bom/pom.xml
@@ -8,13 +8,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boms</groupId>
+    <groupId>org.microshed.boost.boms</groupId>
     <artifactId>ee7-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -23,21 +23,21 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jaxrs</artifactId>
                 <!-- Booster version distinct from the BOM, boost-maven-plugin 
                     version -->
@@ -47,25 +47,25 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jdbc</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jpa</artifactId>
                 <version>2.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>cdi</artifactId>
                 <version>1.2-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonp</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>

--- a/boost-maven/boost-boms/booster-ee7-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee7-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,14 +25,14 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>jdbc</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/boost-maven/boost-boms/booster-ee7-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee7-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,14 +25,14 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jdbc</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/boost-maven/boost-boms/booster-ee7-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee7-bom/pom.xml
@@ -14,7 +14,7 @@
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>boost.boms</groupId>
     <artifactId>ee7-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -23,7 +23,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boms/booster-ee8-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee8-bom/pom.xml
@@ -15,7 +15,7 @@
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>boost.boms</groupId>
     <artifactId>ee8-bom</artifactId>
     <packaging>pom</packaging>
 

--- a/boost-maven/boost-boms/booster-ee8-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee8-bom/pom.xml
@@ -9,13 +9,13 @@
 
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boms</groupId>
+    <groupId>org.microshed.boost.boms</groupId>
     <artifactId>ee8-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -24,21 +24,21 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jaxrs</artifactId>
                 <!-- Booster version distinct from the BOM, boost-maven-plugin 
                     version -->
@@ -48,31 +48,31 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jdbc</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jpa</artifactId>
                 <version>2.2-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>cdi</artifactId>
                 <version>2.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonp</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>bean-validation</artifactId>
                 <version>2.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>

--- a/boost-maven/boost-boms/booster-ee8-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee8-bom/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -26,14 +26,14 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>jdbc</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/boost-maven/boost-boms/booster-ee8-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee8-bom/pom.xml
@@ -24,7 +24,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boms/booster-ee8-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-ee8-bom/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -26,14 +26,14 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -50,7 +50,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jdbc</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>

--- a/boost-maven/boost-boms/booster-mp14-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp14-bom/pom.xml
@@ -14,7 +14,7 @@
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>boost.boms</groupId>
     <artifactId>mp14-bom</artifactId>
     <packaging>pom</packaging>
 

--- a/boost-maven/boost-boms/booster-mp14-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp14-bom/pom.xml
@@ -23,14 +23,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-mp14-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
@@ -38,8 +38,10 @@
             </dependency>
             <dependency>
                 <groupId>boost.runtimes</groupId>
-                <artifactId>openliberty</artifactId>
+                <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-mp14-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp14-bom/pom.xml
@@ -8,13 +8,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boms</groupId>
+    <groupId>org.microshed.boost.boms</groupId>
     <artifactId>mp14-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -23,76 +23,76 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp14-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpHealth</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpConfig</artifactId>
                 <version>1.3-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpOpenTracing</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpMetrics</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpRestClient</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jaxrs</artifactId>
                 <version>2.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonp</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>cdi</artifactId>
                 <version>1.2-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mp-jwt</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>

--- a/boost-maven/boost-boms/booster-mp14-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp14-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,16 +25,26 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>ee8-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>openliberty</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>tomee</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-mp14-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp14-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,21 +25,21 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boms/booster-mp14-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp14-bom/pom.xml
@@ -31,7 +31,7 @@
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>
-                <artifactId>ee8-bom</artifactId>
+                <artifactId>ee7-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -39,11 +39,6 @@
             <dependency>
                 <groupId>boost.runtimes</groupId>
                 <artifactId>openliberty</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>boost.runtimes</groupId>
-                <artifactId>tomee</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
             </dependency>
             <dependency>

--- a/boost-maven/boost-boms/booster-mp20-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp20-bom/pom.xml
@@ -8,13 +8,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boms</groupId>
+    <groupId>org.microshed.boost.boms</groupId>
     <artifactId>mp20-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -23,94 +23,94 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp20-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
              <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpHealth</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpConfig</artifactId>
                 <version>1.3-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpRestClient</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jaxrs</artifactId>
                 <version>2.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonp</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>cdi</artifactId>
                 <version>2.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpOpenTracing</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpMetrics</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpOpenAPI</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>fault-tolerance</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonb</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mp-jwt</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>

--- a/boost-maven/boost-boms/booster-mp20-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp20-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,21 +25,21 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp20-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
              <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boms/booster-mp20-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp20-bom/pom.xml
@@ -14,7 +14,7 @@
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>boost.boms</groupId>
     <artifactId>mp20-bom</artifactId>
     <packaging>pom</packaging>
 

--- a/boost-maven/boost-boms/booster-mp20-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp20-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,16 +25,26 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-mp20-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>ee8-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>openliberty</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>tomee</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-mp20-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp20-bom/pom.xml
@@ -23,28 +23,25 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-mp20-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
-            <dependency>
+             <dependency>
                 <groupId>boost.runtimes</groupId>
-                <artifactId>openliberty</artifactId>
+                <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>boost.runtimes</groupId>
-                <artifactId>tomee</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-mp21-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp21-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,16 +25,26 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-mp21-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>ee8-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>openliberty</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>tomee</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-mp21-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp21-bom/pom.xml
@@ -38,13 +38,10 @@
             </dependency>
             <dependency>
                 <groupId>boost.runtimes</groupId>
-                <artifactId>openliberty</artifactId>
+                <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>boost.runtimes</groupId>
-                <artifactId>tomee</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-mp21-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp21-bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -25,21 +25,21 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp21-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boms/booster-mp21-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp21-bom/pom.xml
@@ -8,13 +8,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boms</groupId>
+    <groupId>org.microshed.boost.boms</groupId>
     <artifactId>mp21-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -23,94 +23,94 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp21-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpHealth</artifactId>
                 <version>1.0.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpConfig</artifactId>
                 <version>1.3-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpOpenAPI</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpRestClient</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jaxrs</artifactId>
                 <version>2.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonp</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>cdi</artifactId>
                 <version>2.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpOpenTracing</artifactId>
                 <version>1.2-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonb</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpMetrics</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>fault-tolerance</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mp-jwt</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>

--- a/boost-maven/boost-boms/booster-mp21-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp21-bom/pom.xml
@@ -14,7 +14,7 @@
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>boost.boms</groupId>
     <artifactId>mp21-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -23,14 +23,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-mp21-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boms/booster-mp22-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp22-bom/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -26,21 +26,21 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp22-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boms/booster-mp22-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp22-bom/pom.xml
@@ -39,13 +39,10 @@
             </dependency>
             <dependency>
                 <groupId>boost.runtimes</groupId>
-                <artifactId>openliberty</artifactId>
+                <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>boost.runtimes</groupId>
-                <artifactId>tomee</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-mp22-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp22-bom/pom.xml
@@ -15,7 +15,7 @@
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>boost.boms</groupId>
     <artifactId>mp22-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -24,14 +24,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-mp22-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boms/booster-mp22-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp22-bom/pom.xml
@@ -9,13 +9,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.boms</groupId>
+    <groupId>org.microshed.boost.boms</groupId>
     <artifactId>mp22-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -24,94 +24,94 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-mp22-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee8-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>runtimes-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpHealth</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpConfig</artifactId>
                 <version>1.3-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpOpenAPI</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpRestClient</artifactId>
                 <version>1.2-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jaxrs</artifactId>
                 <version>2.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonp</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>cdi</artifactId>
                 <version>2.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpOpenTracing</artifactId>
                 <version>1.3-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>    
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>jsonb</artifactId>
                 <version>1.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>    
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mpMetrics</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>        
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>fault-tolerance</artifactId>
                 <version>2.0-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>        
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>org.microshed.boost.boosters</groupId>
                 <artifactId>mp-jwt</artifactId>
                 <version>1.1-1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>

--- a/boost-maven/boost-boms/booster-mp22-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-mp22-bom/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -26,16 +26,26 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-mp22-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>ee8-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>openliberty</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>boost.runtimes</groupId>
+                <artifactId>tomee</artifactId>
+                <version>1.0-M1-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>

--- a/boost-maven/boost-boms/booster-runtimes-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-runtimes-bom/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
         <relativePath>../..</relativePath>
     </parent>
 
@@ -26,15 +26,15 @@
             <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>openliberty</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>provided</scope>
             </dependency>
             <!--<dependency> <groupId>org.microshed.boost.runtimes</groupId> <artifactId>wlp</artifactId> 
-                <version>1.0-M1-SNAPSHOT</version> <scope>provided</scope> </dependency> -->
+                <version>0.2</version> <scope>provided</scope> </dependency> -->
             <dependency>
                 <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>tomee</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>

--- a/boost-maven/boost-boms/booster-runtimes-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-runtimes-bom/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/boost-maven/boost-boms/booster-runtimes-bom/pom.xml
+++ b/boost-maven/boost-boms/booster-runtimes-bom/pom.xml
@@ -9,13 +9,13 @@
 
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 
-    <groupId>boost.runtimes</groupId>
+    <groupId>org.microshed.boost.runtimes</groupId>
     <artifactId>runtimes-bom</artifactId>
     <packaging>pom</packaging>
 
@@ -24,15 +24,15 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>openliberty</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>
             </dependency>
-            <!--<dependency> <groupId>boost.runtimes</groupId> <artifactId>wlp</artifactId> 
+            <!--<dependency> <groupId>org.microshed.boost.runtimes</groupId> <artifactId>wlp</artifactId> 
                 <version>1.0-M1-SNAPSHOT</version> <scope>provided</scope> </dependency> -->
             <dependency>
-                <groupId>boost.runtimes</groupId>
+                <groupId>org.microshed.boost.runtimes</groupId>
                 <artifactId>tomee</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>provided</scope>

--- a/boost-maven/boost-boms/pom.xml
+++ b/boost-maven/boost-boms/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
     </parent>
 	
 	<artifactId>boost-boms</artifactId>

--- a/boost-maven/boost-boms/pom.xml
+++ b/boost-maven/boost-boms/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
     </parent>
 	
 	<artifactId>boost-boms</artifactId>

--- a/boost-maven/boost-boms/pom.xml
+++ b/boost-maven/boost-boms/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
     </parent>

--- a/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
+++ b/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>bean-validation</artifactId>
     <version>2.0-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
+++ b/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
+++ b/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
+++ b/boost-maven/boost-boosters/booster-beanValidation20/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-cdi12/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi12/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-cdi12/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi12/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-cdi12/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi12/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>cdi</artifactId>
     <version>1.2-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-cdi12/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi12/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-cdi20/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi20/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>cdi</artifactId>
     <version>2.0-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-cdi20/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi20/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-cdi20/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi20/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-cdi20/pom.xml
+++ b/boost-maven/boost-boosters/booster-cdi20/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jaxrs</artifactId>
     <version>2.0-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs20/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jaxrs21/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jaxrs</artifactId>
     <version>2.1-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jdbc/pom.xml
+++ b/boost-maven/boost-boosters/booster-jdbc/pom.xml
@@ -5,6 +5,6 @@
 
     <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jdbc</artifactId>
-    <version>1.0-M1-SNAPSHOT</version>
+    <version>0.2</version>
 
 </project>

--- a/boost-maven/boost-boosters/booster-jdbc/pom.xml
+++ b/boost-maven/boost-boosters/booster-jdbc/pom.xml
@@ -5,6 +5,6 @@
 
     <groupId>boost.boosters</groupId>
     <artifactId>jdbc</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>1.0-M1-SNAPSHOT</version>
 
 </project>

--- a/boost-maven/boost-boosters/booster-jdbc/pom.xml
+++ b/boost-maven/boost-boosters/booster-jdbc/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jdbc</artifactId>
     <version>1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-jpa21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa21/pom.xml
@@ -10,14 +10,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jpa21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa21/pom.xml
@@ -3,21 +3,21 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jpa</artifactId>
     <version>2.1-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
@@ -29,7 +29,7 @@
     <dependencies>
         <!-- Booster dependencies -->
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>jdbc</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/boost-maven/boost-boosters/booster-jpa21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa21/pom.xml
@@ -12,14 +12,14 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>ee7-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jpa21/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa21/pom.xml
@@ -12,14 +12,14 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jpa22/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa22/pom.xml
@@ -10,14 +10,14 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jpa22/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa22/pom.xml
@@ -12,14 +12,14 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>ee7-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jpa22/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa22/pom.xml
@@ -12,14 +12,14 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jpa22/pom.xml
+++ b/boost-maven/boost-boosters/booster-jpa22/pom.xml
@@ -3,21 +3,21 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jpa</artifactId>
     <version>2.2-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>ee7-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
@@ -29,7 +29,7 @@
     <dependencies>
         <!-- Booster dependencies -->
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>jdbc</artifactId>
             <scope>compile</scope>
         </dependency>

--- a/boost-maven/boost-boosters/booster-jsonb10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonb10/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jsonb</artifactId>
     <version>1.0-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jsonb10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonb10/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jsonb10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonb10/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jsonb10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonb10/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jsonp10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp10/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jsonp10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp10/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jsonp10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp10/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jsonp</artifactId>
     <version>1.0-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jsonp10/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp10/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee7-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jsonp11/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp11/pom.xml
@@ -3,14 +3,14 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>jsonp</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-jsonp11/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp11/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jsonp11/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp11/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-boosters/booster-jsonp11/pom.xml
+++ b/boost-maven/boost-boosters/booster-jsonp11/pom.xml
@@ -10,7 +10,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>boost-ee8-apis-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-boosters/booster-mp-jwt11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mp-jwt11/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mp-jwt</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpConfig13/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpConfig13/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpConfig</artifactId>
     <version>1.3-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+    <properties>
+        <mp-config-api-version>1.3</mp-config-api-version>
+    </properties>
+    
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
+            <version>${mp-config-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpConfig13/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpConfig13/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpConfig</artifactId>
     <version>1.3-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpFaultTolerance11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpFaultTolerance11/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpFaultTolerance</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-fault-tolerance-api-version>1.1</mp-fault-tolerance-api-version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
+            <version>${mp-fault-tolerance-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpFaultTolerance11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpFaultTolerance11/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpFaultTolerance</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpFaultTolerance20/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpFaultTolerance20/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpFaultTolerance</artifactId>
     <version>2.0-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp22-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-fault-tolerance-api-version>2.0</mp-fault-tolerance-api-version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
+            <version>${mp-fault-tolerance-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpFaultTolerance20/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpFaultTolerance20/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpFaultTolerance</artifactId>
     <version>2.0-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpHealth10/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpHealth10/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpHealth</artifactId>
     <version>1.0-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-health-api-version>1.0</mp-health-api-version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.health</groupId>
             <artifactId>microprofile-health-api</artifactId>
+            <version>${mp-health-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpHealth10/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpHealth10/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpHealth</artifactId>
     <version>1.0-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpMetrics11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpMetrics11/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpMetrics</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpMetrics11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpMetrics11/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpMetrics</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-metrics-api-version>1.1</mp-metrics-api-version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
+            <version>${mp-metrics-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpOpenAPI10/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenAPI10/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpOpenAPI</artifactId>
     <version>1.0-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-openapi-api-version>1.0</mp-openapi-api-version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
+            <version>${mp-openapi-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpOpenAPI10/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenAPI10/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpOpenAPI</artifactId>
     <version>1.0-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpOpenAPI11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenAPI11/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpOpenAPI</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp22-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-openapi-api-version>1.1</mp-openapi-api-version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.openapi</groupId>
             <artifactId>microprofile-openapi-api</artifactId>
+            <version>${mp-openapi-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpOpenAPI11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenAPI11/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpOpenAPI</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpOpenTracing11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenTracing11/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpOpenTracing</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpOpenTracing11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenTracing11/pom.xml
@@ -7,22 +7,16 @@
     <artifactId>mpOpenTracing</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-open-tracing-api-version>1.1</mp-open-tracing-api-version>
+    </properties>
+
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
+            <version>${mp-open-tracing-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpOpenTracing12/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenTracing12/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpOpenTracing</artifactId>
     <version>1.2-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpOpenTracing12/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenTracing12/pom.xml
@@ -7,22 +7,16 @@
     <artifactId>mpOpenTracing</artifactId>
     <version>1.2-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp20-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-open-tracing-api-version>1.2</mp-open-tracing-api-version>
+    </properties>
+
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
+            <version>${mp-open-tracing-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpOpenTracing13/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenTracing13/pom.xml
@@ -7,22 +7,16 @@
     <artifactId>mpOpenTracing</artifactId>
     <version>1.3-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp22-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-open-tracing-api-version>1.3</mp-open-tracing-api-version>
+    </properties>
+
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-api</artifactId>
+            <version>${mp-open-tracing-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpOpenTracing13/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpOpenTracing13/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpOpenTracing</artifactId>
     <version>1.3-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpRestClient11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpRestClient11/pom.xml
@@ -7,22 +7,16 @@
     <artifactId>mpRestClient</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp14-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-rest-client-api-version>1.1</mp-rest-client-api-version>
+    </properties>
+
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${mp-rest-client-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/booster-mpRestClient11/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpRestClient11/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpRestClient</artifactId>
     <version>1.1-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpRestClient12/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpRestClient12/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.boosters</groupId>
+    <groupId>org.microshed.boost.boosters</groupId>
     <artifactId>mpRestClient</artifactId>
     <version>1.2-1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-boosters/booster-mpRestClient12/pom.xml
+++ b/boost-maven/boost-boosters/booster-mpRestClient12/pom.xml
@@ -7,22 +7,15 @@
     <artifactId>mpRestClient</artifactId>
     <version>1.2-1.0-M1-SNAPSHOT</version>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>boost.boosters</groupId>
-                <artifactId>boost-mp22-apis-bom</artifactId>
-                <version>0.1-SNAPSHOT</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+    <properties>
+        <mp-rest-client-api-version>1.2</mp-rest-client-api-version>
+    </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${mp-rest-client-api-version}</version>
         </dependency>
     </dependencies>
 

--- a/boost-maven/boost-boosters/pom.xml
+++ b/boost-maven/boost-boosters/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
     </parent>

--- a/boost-maven/boost-boosters/pom.xml
+++ b/boost-maven/boost-boosters/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
     </parent>
 
     <artifactId>boost-boosters</artifactId>

--- a/boost-maven/boost-boosters/pom.xml
+++ b/boost-maven/boost-boosters/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>boost-boosters</artifactId>

--- a/boost-maven/boost-maven-plugin/pom.xml
+++ b/boost-maven/boost-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
     </parent>
 
     <artifactId>boost-maven-plugin</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.microshed.boost</groupId>
             <artifactId>boost-common</artifactId>
-            <version>1.0-M1-SNAPSHOT</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.tools</groupId>

--- a/boost-maven/boost-maven-plugin/pom.xml
+++ b/boost-maven/boost-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>boost-maven-plugin</artifactId>
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>boost</groupId>
             <artifactId>boost-common</artifactId>
-            <version>0.1.3-SNAPSHOT</version>
+            <version>1.0-M1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.tools</groupId>

--- a/boost-maven/boost-maven-plugin/pom.xml
+++ b/boost-maven/boost-maven-plugin/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
     </parent>
@@ -21,7 +21,7 @@
 
         <!-- Boost dependencies -->
         <dependency>
-            <groupId>boost</groupId>
+            <groupId>org.microshed.boost</groupId>
             <artifactId>boost-common</artifactId>
             <version>1.0-M1-SNAPSHOT</version>
         </dependency>

--- a/boost-maven/boost-maven-plugin/src/it/test-dev-release/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-dev-release/pom.xml
@@ -5,7 +5,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost.test</groupId>
+	<groupId>org.microshed.boost.test</groupId>
 	<artifactId>test-dev-release</artifactId>
 	<version>@pom.version@</version>
 

--- a/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/dev-project/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/dev-project/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>dev-project</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -32,14 +32,14 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boms</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
 			<dependency>
-				<groupId>boost.boms</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>mp20-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
@@ -50,19 +50,19 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jdbc</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>mpHealth</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>cdi</artifactId>
 		</dependency>
     </dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/dev-project/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/dev-project/pom.xml
@@ -32,14 +32,14 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>boost.boms</groupId>
 				<artifactId>mp20-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/release-project/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/release-project/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>release-project</artifactId>
 	<packaging>jar</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -32,7 +32,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.runtimes</groupId>
+				<groupId>org.microshed.boost.runtimes</groupId>
 				<artifactId>runtimes-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
@@ -43,7 +43,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost</groupId>
+			<groupId>org.microshed.boost</groupId>
 			<artifactId>dev-project</artifactId>
 			<type>war</type>
 			<version>1.0-SNAPSHOT</version>
@@ -71,7 +71,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<executions>
@@ -123,7 +123,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -138,7 +138,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -153,7 +153,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-dynamic-update/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-dynamic-update/pom.xml
@@ -31,7 +31,7 @@
 	<dependencyManagement>
 		<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>boost.boms</groupId>
 			<artifactId>ee8-bom</artifactId>
 			<version>@pom.version@</version>
 			<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-dynamic-update/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-dynamic-update/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>test-dynamic-update</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -31,7 +31,7 @@
 	<dependencyManagement>
 		<dependencies>
 		<dependency>
-			<groupId>boost.boms</groupId>
+			<groupId>org.microshed.boost.boms</groupId>
 			<artifactId>ee8-bom</artifactId>
 			<version>@pom.version@</version>
 			<scope>import</scope>
@@ -42,7 +42,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>	
 		<dependency>
@@ -62,7 +62,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<extensions>true</extensions>	
@@ -115,7 +115,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -130,7 +130,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -145,7 +145,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.0/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.0/pom.xml
@@ -33,7 +33,7 @@
 	<dependencyManagement>
 		<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>boost.boms</groupId>
 			<artifactId>ee7-bom</artifactId>
 			<version>@pom.version@</version>
 			<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.0/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.0/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>test-jaxrs-2.0</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -33,7 +33,7 @@
 	<dependencyManagement>
 		<dependencies>
 		<dependency>
-			<groupId>boost.boms</groupId>
+			<groupId>org.microshed.boost.boms</groupId>
 			<artifactId>ee7-bom</artifactId>
 			<version>@pom.version@</version>
 			<scope>import</scope>
@@ -44,7 +44,7 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
@@ -64,7 +64,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<executions>
@@ -116,7 +116,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -131,7 +131,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -146,7 +146,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>test-jaxrs-2.1</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -32,7 +32,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boms</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
@@ -43,11 +43,11 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>bean-validation</artifactId>
     	</dependency>
 		<dependency>
@@ -67,7 +67,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<executions>
@@ -119,7 +119,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -134,7 +134,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -149,7 +149,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-    				<groupId>boost.runtimes</groupId>
+    				<groupId>org.microshed.boost.runtimes</groupId>
     				<artifactId>tomee</artifactId>
     			</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/pom.xml
@@ -32,7 +32,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>test-jdbc-db2</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -32,7 +32,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boms</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
@@ -43,11 +43,11 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jdbc</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
@@ -78,7 +78,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<executions>
@@ -163,7 +163,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -178,7 +178,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -193,7 +193,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/pom.xml
@@ -32,7 +32,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
@@ -30,7 +30,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>boost.boms</groupId>
 				<artifactId>mp20-bom</artifactId>
 				<version>1.0-M1-SNAPSHOT</version>
 				<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
@@ -32,7 +32,7 @@
 			<dependency>
 				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>mp20-bom</artifactId>
-				<version>1.0-M1-SNAPSHOT</version>
+				<version>0.2</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -249,7 +249,7 @@
 			<plugin>
 				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
-				<version>1.0-M1-SNAPSHOT</version>
+				<version>0.2</version>
 				<executions>
 					<execution>
 						<goals>

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>test-jdbc</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -30,7 +30,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boms</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>mp20-bom</artifactId>
 				<version>1.0-M1-SNAPSHOT</version>
 				<scope>import</scope>
@@ -42,23 +42,23 @@
 	<dependencies>
 		<!-- Boosters -->
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jdbc</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>mpHealth</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>mpRestClient</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>cdi</artifactId>
 		</dependency>
 
@@ -110,7 +110,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -125,7 +125,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -140,7 +140,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>
@@ -247,7 +247,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>1.0-M1-SNAPSHOT</version>
 				<executions>

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
@@ -32,7 +32,7 @@
 			<dependency>
 				<groupId>boost.boosters</groupId>
 				<artifactId>mp20-bom</artifactId>
-				<version>0.1.3-SNAPSHOT</version>
+				<version>1.0-M1-SNAPSHOT</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -249,7 +249,7 @@
 			<plugin>
 				<groupId>boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
-				<version>0.1.3-SNAPSHOT</version>
+				<version>1.0-M1-SNAPSHOT</version>
 				<executions>
 					<execution>
 						<goals>

--- a/boost-maven/boost-maven-plugin/src/it/test-jpa-2.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jpa-2.1/pom.xml
@@ -4,7 +4,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>test-jpa-2.1</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -19,7 +19,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boms</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>ee7-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
@@ -30,11 +30,11 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jpa</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
@@ -74,7 +74,7 @@
 		<plugins>
 
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<executions>
@@ -127,7 +127,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -142,7 +142,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -157,7 +157,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-jpa-2.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jpa-2.1/pom.xml
@@ -19,7 +19,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>boost.boms</groupId>
 				<artifactId>ee7-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-jpa-2.2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jpa-2.2/pom.xml
@@ -19,7 +19,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boosters</groupId>
+				<groupId>boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-jpa-2.2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jpa-2.2/pom.xml
@@ -4,7 +4,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>boost</groupId>
+	<groupId>org.microshed.boost</groupId>
 	<artifactId>test-jpa-2.1</artifactId>
 	<packaging>war</packaging>
 	<version>1.0-SNAPSHOT</version>
@@ -19,7 +19,7 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>boost.boms</groupId>
+				<groupId>org.microshed.boost.boms</groupId>
 				<artifactId>ee8-bom</artifactId>
 				<version>@pom.version@</version>
 				<scope>import</scope>
@@ -30,15 +30,15 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jpa</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jdbc</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>boost.boosters</groupId>
+			<groupId>org.microshed.boost.boosters</groupId>
 			<artifactId>jaxrs</artifactId>
 		</dependency>
 		<dependency>
@@ -77,7 +77,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<executions>
@@ -130,7 +130,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -145,7 +145,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -160,7 +160,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-jwt-1.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-jwt-1.1/pom.xml
@@ -46,7 +46,7 @@
    <dependencyManagement>
       <dependencies>
           <dependency>
-              <groupId>boost.boosters</groupId>
+              <groupId>boost.boms</groupId>
               <artifactId>mp20-bom</artifactId>
               <version>@pom.version@</version>
               <type>pom</type>

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-jwt-1.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-jwt-1.1/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>boost</groupId>
+  <groupId>org.microshed.boost</groupId>
   <artifactId>test-mpJwt-1.1</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>war</packaging>
@@ -46,7 +46,7 @@
    <dependencyManagement>
       <dependencies>
           <dependency>
-              <groupId>boost.boms</groupId>
+              <groupId>org.microshed.boost.boms</groupId>
               <artifactId>mp20-bom</artifactId>
               <version>@pom.version@</version>
               <type>pom</type>
@@ -60,23 +60,23 @@
   <dependencies>
      <!-- Open Liberty features -->
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>jaxrs</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>jsonp</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>mpConfig</artifactId>
     </dependency>
     <dependency>
-       <groupId>boost.boosters</groupId>
+       <groupId>org.microshed.boost.boosters</groupId>
        <artifactId>mp-jwt</artifactId>
     </dependency>
         <!-- For testing -->
@@ -161,7 +161,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>boost</groupId>
+                <groupId>org.microshed.boost</groupId>
                 <artifactId>boost-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>
@@ -235,7 +235,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -250,7 +250,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -265,7 +265,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpHealth-1.0/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpHealth-1.0/pom.xml
@@ -33,7 +33,7 @@
   <dependencyManagement>
       <dependencies>
           <dependency>
-              <groupId>boost.boosters</groupId>
+              <groupId>boost.boms</groupId>
               <artifactId>mp14-bom</artifactId>
               <version>@pom.version@</version>
               <type>pom</type>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpHealth-1.0/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpHealth-1.0/pom.xml
@@ -34,7 +34,7 @@
       <dependencies>
           <dependency>
               <groupId>boost.boosters</groupId>
-              <artifactId>mp20-bom</artifactId>
+              <artifactId>mp14-bom</artifactId>
               <version>@pom.version@</version>
               <type>pom</type>
               <scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpHealth-1.0/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpHealth-1.0/pom.xml
@@ -33,7 +33,7 @@
   <dependencyManagement>
       <dependencies>
           <dependency>
-              <groupId>boost.boms</groupId>
+              <groupId>org.microshed.boost.boms</groupId>
               <artifactId>mp14-bom</artifactId>
               <version>@pom.version@</version>
               <type>pom</type>
@@ -70,27 +70,27 @@
     </dependency>
     <!-- Open Liberty features -->
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>jaxrs</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>jsonp</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>cdi</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>mpConfig</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>mpRestClient</artifactId>
     </dependency>
     <dependency>
-        <groupId>boost.boosters</groupId>
+        <groupId>org.microshed.boost.boosters</groupId>
         <artifactId>mpHealth</artifactId>
     </dependency>
 	<!-- Java utility classes -->
@@ -115,7 +115,7 @@
   <build>
     <plugins>
       <plugin>
-				<groupId>boost</groupId>
+				<groupId>org.microshed.boost</groupId>
 				<artifactId>boost-maven-plugin</artifactId>
 				<version>@pom.version@</version>
 				<executions>
@@ -167,7 +167,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>openliberty</artifactId>
 				</dependency>
 			</dependencies>
@@ -182,7 +182,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>wlp</artifactId>
 				</dependency>
 			</dependencies>
@@ -197,7 +197,7 @@
 			</activation>
 			<dependencies>
 				<dependency>
-					<groupId>boost.runtimes</groupId>
+					<groupId>org.microshed.boost.runtimes</groupId>
 					<artifactId>tomee</artifactId>
 				</dependency>
 			</dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.1/pom.xml
@@ -20,23 +20,23 @@
     <dependencies>
         <!-- Boosters -->
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>mpConfig</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>mpRestClient</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>jaxrs</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>cdi</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>jsonp</artifactId>
         </dependency>
         <dependency>
@@ -82,7 +82,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>boost</groupId>
+                <groupId>org.microshed.boost</groupId>
                 <artifactId>boost-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>
@@ -148,7 +148,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>mp21-bom</artifactId>
                 <version>@pom.version@</version>
                 <scope>import</scope>
@@ -168,7 +168,7 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>boost.runtimes</groupId>
+                    <groupId>org.microshed.boost.runtimes</groupId>
                     <artifactId>openliberty</artifactId>
                 </dependency>
             </dependencies>
@@ -183,7 +183,7 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>boost.runtimes</groupId>
+                    <groupId>org.microshed.boost.runtimes</groupId>
                     <artifactId>wlp</artifactId>
                 </dependency>
             </dependencies>
@@ -198,7 +198,7 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>boost.runtimes</groupId>
+                    <groupId>org.microshed.boost.runtimes</groupId>
                     <artifactId>tomee</artifactId>
                 </dependency>
             </dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.1/pom.xml
@@ -148,7 +148,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>mp21-bom</artifactId>
                 <version>@pom.version@</version>
                 <scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>mp22-bom</artifactId>
-                <version>1.0-M1-SNAPSHOT</version>
+                <version>0.2</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
@@ -21,7 +21,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boosters</groupId>
+                <groupId>boost.boms</groupId>
                 <artifactId>mp22-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
@@ -21,7 +21,7 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>boost.boms</groupId>
+                <groupId>org.microshed.boost.boms</groupId>
                 <artifactId>mp22-bom</artifactId>
                 <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
@@ -34,23 +34,23 @@
     <dependencies>
         <!-- Boosters -->
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>mpConfig</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>mpRestClient</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>jaxrs</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>cdi</artifactId>
         </dependency>
         <dependency>
-            <groupId>boost.boosters</groupId>
+            <groupId>org.microshed.boost.boosters</groupId>
             <artifactId>jsonp</artifactId>
         </dependency>
         <dependency>
@@ -96,7 +96,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>boost</groupId>
+                <groupId>org.microshed.boost</groupId>
                 <artifactId>boost-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>
@@ -178,7 +178,7 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>boost.runtimes</groupId>
+                    <groupId>org.microshed.boost.runtimes</groupId>
                     <artifactId>openliberty</artifactId>
                 </dependency>
             </dependencies>
@@ -193,7 +193,7 @@
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>boost.runtimes</groupId>
+                    <groupId>org.microshed.boost.runtimes</groupId>
                     <artifactId>wlp</artifactId>
                 </dependency>
             </dependencies>
@@ -212,7 +212,7 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>boost.runtimes</groupId>
+                    <groupId>org.microshed.boost.runtimes</groupId>
                     <artifactId>tomee</artifactId>
                 </dependency>
             </dependencies>

--- a/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-mpRestClient-1.2/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>boost.boosters</groupId>
                 <artifactId>mp22-bom</artifactId>
-                <version>0.1.3-SNAPSHOT</version>
+                <version>1.0-M1-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/boost-maven/boost-runtimes/pom.xml
+++ b/boost-maven/boost-runtimes/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>boost</groupId>
+        <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
         <version>1.0-M1-SNAPSHOT</version>
     </parent>

--- a/boost-maven/boost-runtimes/pom.xml
+++ b/boost-maven/boost-runtimes/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>0.1.3-SNAPSHOT</version>
+        <version>1.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>boost-runtimes</artifactId>

--- a/boost-maven/boost-runtimes/pom.xml
+++ b/boost-maven/boost-runtimes/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.microshed.boost</groupId>
         <artifactId>boost-maven-parent</artifactId>
-        <version>1.0-M1-SNAPSHOT</version>
+        <version>0.2</version>
     </parent>
 
     <artifactId>boost-runtimes</artifactId>

--- a/boost-maven/boost-runtimes/runtime-openliberty/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-openliberty/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.runtimes</groupId>
+    <groupId>org.microshed.boost.runtimes</groupId>
     <artifactId>openliberty</artifactId>
     <version>1.0-M1-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -17,12 +17,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>boost</groupId>
+            <groupId>org.microshed.boost</groupId>
             <artifactId>boost-common</artifactId>
             <version>1.0-M1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>boost</groupId>
+            <groupId>org.microshed.boost</groupId>
             <artifactId>boost-maven-plugin</artifactId>
             <version>1.0-M1-SNAPSHOT</version>
         </dependency>

--- a/boost-maven/boost-runtimes/runtime-openliberty/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-openliberty/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.microshed.boost.runtimes</groupId>
     <artifactId>openliberty</artifactId>
-    <version>1.0-M1-SNAPSHOT</version>
+    <version>0.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>org.microshed.boost</groupId>
             <artifactId>boost-common</artifactId>
-            <version>1.0-M1-SNAPSHOT</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>org.microshed.boost</groupId>
             <artifactId>boost-maven-plugin</artifactId>
-            <version>1.0-M1-SNAPSHOT</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.tools</groupId>

--- a/boost-maven/boost-runtimes/runtime-openliberty/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-openliberty/pom.xml
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>boost</groupId>
             <artifactId>boost-common</artifactId>
-            <version>0.1.3-SNAPSHOT</version>
+            <version>1.0-M1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>boost</groupId>
             <artifactId>boost-maven-plugin</artifactId>
-            <version>0.1.3-SNAPSHOT</version>
+            <version>1.0-M1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.openliberty.tools</groupId>

--- a/boost-maven/boost-runtimes/runtime-openliberty/src/test/java/io/openliberty/boost/runtimes/boosters/MPOpenTracingBoosterTest.java
+++ b/boost-maven/boost-runtimes/runtime-openliberty/src/test/java/io/openliberty/boost/runtimes/boosters/MPOpenTracingBoosterTest.java
@@ -98,7 +98,7 @@ public class MPOpenTracingBoosterTest {
 
     /**
      * Test that the mpOpenTracing-1.3 feature is added to server.xml when the
-     * MPOpenTracing booster version is set to 0.1.3-SNAPSHOT
+     * MPOpenTracing booster version is set to 1.0-M1-SNAPSHOT
      * 
      */
     @Test

--- a/boost-maven/boost-runtimes/runtime-openliberty/src/test/java/io/openliberty/boost/runtimes/utils/BoosterUtil.java
+++ b/boost-maven/boost-runtimes/runtime-openliberty/src/test/java/io/openliberty/boost/runtimes/utils/BoosterUtil.java
@@ -28,6 +28,6 @@ public class BoosterUtil {
     }
 
     public static Map<String, String> getJDBCDependency() throws BoostException {
-        return BoosterUtil.createDependenciesWithBoosterAndVersion(JDBCBoosterConfig.class, "0.1-SNAPSHOT");
+        return BoosterUtil.createDependenciesWithBoosterAndVersion(JDBCBoosterConfig.class, "1.0-M1-SNAPSHOT");
     }
 }

--- a/boost-maven/boost-runtimes/runtime-tomee/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-tomee/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.microshed.boost.runtimes</groupId>
     <artifactId>tomee</artifactId>
-    <version>1.0-M1-SNAPSHOT</version>
+    <version>0.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>org.microshed.boost</groupId>
             <artifactId>boost-common</artifactId>
-            <version>1.0-M1-SNAPSHOT</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>org.microshed.boost</groupId>
             <artifactId>boost-maven-plugin</artifactId>
-            <version>1.0-M1-SNAPSHOT</version>
+            <version>0.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/boost-maven/boost-runtimes/runtime-tomee/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-tomee/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.runtimes</groupId>
+    <groupId>org.microshed.boost.runtimes</groupId>
     <artifactId>tomee</artifactId>
     <version>1.0-M1-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -17,12 +17,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>boost</groupId>
+            <groupId>org.microshed.boost</groupId>
             <artifactId>boost-common</artifactId>
             <version>1.0-M1-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>boost</groupId>
+            <groupId>org.microshed.boost</groupId>
             <artifactId>boost-maven-plugin</artifactId>
             <version>1.0-M1-SNAPSHOT</version>
         </dependency>

--- a/boost-maven/boost-runtimes/runtime-tomee/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-tomee/pom.xml
@@ -19,12 +19,12 @@
         <dependency>
             <groupId>boost</groupId>
             <artifactId>boost-common</artifactId>
-            <version>0.1.3-SNAPSHOT</version>
+            <version>1.0-M1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>boost</groupId>
             <artifactId>boost-maven-plugin</artifactId>
-            <version>0.1.3-SNAPSHOT</version>
+            <version>1.0-M1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/boost-maven/boost-runtimes/runtime-wlp/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-wlp/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost.runtimes</groupId>
+    <groupId>org.microshed.boost.runtimes</groupId>
     <artifactId>wlp</artifactId>
     <version>1.0-M1-SNAPSHOT</version>
 

--- a/boost-maven/boost-runtimes/runtime-wlp/pom.xml
+++ b/boost-maven/boost-runtimes/runtime-wlp/pom.xml
@@ -5,6 +5,6 @@
 
     <groupId>org.microshed.boost.runtimes</groupId>
     <artifactId>wlp</artifactId>
-    <version>1.0-M1-SNAPSHOT</version>
+    <version>0.2</version>
 
 </project>

--- a/boost-maven/pom.xml
+++ b/boost-maven/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>org.microshed.boost</groupId>
     <artifactId>boost-maven-parent</artifactId>
-    <version>1.0-M1-SNAPSHOT</version>
+    <version>0.2</version>
     <packaging>pom</packaging>
 
     <name>boost-maven-plugin Parent</name>

--- a/boost-maven/pom.xml
+++ b/boost-maven/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>boost</groupId>
     <artifactId>boost-maven-parent</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>1.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>boost-maven-plugin Parent</name>

--- a/boost-maven/pom.xml
+++ b/boost-maven/pom.xml
@@ -7,7 +7,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>boost</groupId>
+    <groupId>org.microshed.boost</groupId>
     <artifactId>boost-maven-parent</artifactId>
     <version>1.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>


### PR DESCRIPTION
org.microshed name was approved - move boost group id to use this as a prefix to the existing name structures. Also - move the boms and plugin version to "0.2"