### PR TITLE
move boost var names to use underscores vs dots

### DIFF
--- a/boost-common/src/main/java/boost/common/boosters/JDBCBoosterConfig.java
+++ b/boost-common/src/main/java/boost/common/boosters/JDBCBoosterConfig.java
@@ -112,7 +112,7 @@ public class JDBCBoosterConfig extends AbstractBoosterConfig {
 
         Properties datasourceProperties = new Properties();
 
-        // Find and add all "boost.db." properties.
+        // Find and add all "boost_db_" properties.
         for (String key : boostConfigProperties.stringPropertyNames()) {
             if (key.startsWith(BoostProperties.DATASOURCE_PREFIX)) {
                 String value = (String) boostConfigProperties.get(key);

--- a/boost-common/src/main/java/boost/common/config/BoostProperties.java
+++ b/boost-common/src/main/java/boost/common/config/BoostProperties.java
@@ -39,7 +39,7 @@ public final class BoostProperties {
 
     public static final String AES_ENCRYPTION_KEY = "boost_aes_key";
 
-    public static final String INTERNAL_COMPILER_TARGET = "boost_internal_compiler_target";
+    public static final String INTERNAL_COMPILER_TARGET = "boost.internal.compiler.target";
 
     /**
      * Return a list of all properties that need to be encrypted

--- a/boost-common/src/main/java/boost/common/config/BoostProperties.java
+++ b/boost-common/src/main/java/boost/common/config/BoostProperties.java
@@ -19,24 +19,27 @@ import boost.common.BoostLoggerI;
 
 public final class BoostProperties {
 
+    // Boost specific
+    public static final String BOOST_PROP_PREFIX = "boost_";
+
     // HTTP Endpoint properties
-    public static final String ENDPOINT_HOST = "boost.http.host";
-    public static final String ENDPOINT_HTTP_PORT = "boost.http.port";
-    public static final String ENDPOINT_HTTPS_PORT = "boost.http.securePort";
+    public static final String ENDPOINT_HOST = "boost_http_host";
+    public static final String ENDPOINT_HTTP_PORT = "boost_http_port";
+    public static final String ENDPOINT_HTTPS_PORT = "boost_http_securePort";
 
     // Datasource default properties
-    public static final String DATASOURCE_PREFIX = "boost.db.";
-    public static final String DATASOURCE_DATABASE_NAME = "boost.db.databaseName";
-    public static final String DATASOURCE_SERVER_NAME = "boost.db.serverName";
-    public static final String DATASOURCE_PORT_NUMBER = "boost.db.portNumber";
-    public static final String DATASOURCE_USER = "boost.db.user";
-    public static final String DATASOURCE_PASSWORD = "boost.db.password";
-    public static final String DATASOURCE_CREATE_DATABASE = "boost.db.createDatabase";
-    public static final String DATASOURCE_URL = "boost.db.url";
+    public static final String DATASOURCE_PREFIX = "boost_db_";
+    public static final String DATASOURCE_DATABASE_NAME = "boost_db_databaseName";
+    public static final String DATASOURCE_SERVER_NAME = "boost_db_serverName";
+    public static final String DATASOURCE_PORT_NUMBER = "boost_db_portNumber";
+    public static final String DATASOURCE_USER = "boost_db_user";
+    public static final String DATASOURCE_PASSWORD = "boost_db_password";
+    public static final String DATASOURCE_CREATE_DATABASE = "boost_db_createDatabase";
+    public static final String DATASOURCE_URL = "boost_db_url";
 
-    public static final String AES_ENCRYPTION_KEY = "boost.aes.key";
+    public static final String AES_ENCRYPTION_KEY = "boost_aes_key";
 
-    public static final String INTERNAL_COMPILER_TARGET = "boost.internal.compiler.target";
+    public static final String INTERNAL_COMPILER_TARGET = "boost_internal_compiler_target";
 
     /**
      * Return a list of all properties that need to be encrypted
@@ -57,11 +60,11 @@ public final class BoostProperties {
 
         Properties boostProperties = new Properties();
 
-        // Add project properties first to allow them to be overriden by 
+        // Add project properties first to allow them to be overriden by
         // system properties (set at command line)
         for (Map.Entry<Object, Object> entry : projectProperties.entrySet()) {
 
-            if (entry.getKey().toString().startsWith("boost.")) {
+            if (entry.getKey().toString().startsWith(BOOST_PROP_PREFIX)) {
 
                 // logger.debug("Found boost property: " +
                 // entry.getKey() + ":" + entry.getValue());
@@ -69,10 +72,10 @@ public final class BoostProperties {
                 boostProperties.put(entry.getKey(), entry.getValue());
             }
         }
-        
+
         for (Map.Entry<Object, Object> entry : systemProperties.entrySet()) {
 
-            if (entry.getKey().toString().startsWith("boost.")) {
+            if (entry.getKey().toString().startsWith(BOOST_PROP_PREFIX)) {
 
                 // logger.debug("Found boost property: " +
                 // entry.getKey() + ":" + entry.getValue());

--- a/boost-gradle/src/test/groovy/BoostPackageJdbcDb2AesTest.groovy
+++ b/boost-gradle/src/test/groovy/BoostPackageJdbcDb2AesTest.groovy
@@ -54,7 +54,7 @@ public class BoostPackageJdbcDb2AesTest extends AbstractBoostTest {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir)
             .forwardOutput()
-            .withArguments("clean", "boostPackage", "-Dboost.db.databaseName=myCustomDB", "-Dboost.db.user=user", "-Dboost.db.password=password", "-Dboost.aes.key=test", "-i", "-s")
+            .withArguments("clean", "boostPackage", "-Dboost_db_databaseName=myCustomDB", "-Dboost_db_user=user", "-Dboost_db_password=password", "-Dboost_aes_key=test", "-i", "-s")
             .build()
             
         assertEquals(SUCCESS, result.task(":boostPackage").getOutcome())
@@ -67,10 +67,10 @@ public class BoostPackageJdbcDb2AesTest extends AbstractBoostTest {
 
             bootstrapProperties.load(input)
 
-            assertEquals("Incorrect boost.db.user found in bootstrap.properties.", DB_USER, bootstrapProperties.getProperty("boost.db.user"))
-            assertEquals("Incorrect boost.db.databaseName found in bootstrap.properties.", DB_NAME, bootstrapProperties.getProperty("boost.db.databaseName"))
+            assertEquals("Incorrect boost_db_user found in bootstrap.properties.", DB_USER, bootstrapProperties.getProperty("boost_db_user"))
+            assertEquals("Incorrect boost_db_databaseName found in bootstrap.properties.", DB_NAME, bootstrapProperties.getProperty("boost_db_databaseName"))
             //AES hashed password changes so we're just going to look for the aes flag.
-            assertTrue("Incorrect boost.db.password found in bootstrap.properties.", bootstrapProperties.getProperty("boost.db.password").contains(AES_HASHED_PASSWORD_FLAG))
+            assertTrue("Incorrect boost_db_password found in bootstrap.properties.", bootstrapProperties.getProperty("boost_db_password").contains(AES_HASHED_PASSWORD_FLAG))
         } catch (IOException ex) {
             ex.printStackTrace()
         } finally {
@@ -92,7 +92,7 @@ public class BoostPackageJdbcDb2AesTest extends AbstractBoostTest {
         BuildResult result = GradleRunner.create()
             .withProjectDir(testProjectDir)
             .forwardOutput()
-            .withArguments("clean", "boostPackage", "-Dboost.db.databaseName=myCustomDB", "-Dboost.db.user=user", "-Dboost.db.password={aes}Lz4sLCgwLTs=", "-Dboost.aes.key=test", "-i", "-s")
+            .withArguments("clean", "boostPackage", "-Dboost_db_databaseName=myCustomDB", "-Dboost_db_user=user", "-Dboost_db_password={aes}Lz4sLCgwLTs=", "-Dboost_aes_key=test", "-i", "-s")
             .build()
             
         assertEquals(SUCCESS, result.task(":boostPackage").getOutcome())
@@ -105,9 +105,9 @@ public class BoostPackageJdbcDb2AesTest extends AbstractBoostTest {
 
             bootstrapProperties.load(input)
 
-            assertEquals("Incorrect boost.db.user found in bootstrap.properties.", DB_USER, bootstrapProperties.getProperty("boost.db.user"))
-            assertEquals("Incorrect boost.db.password found in bootstrap.properties.", AES_HASHED_PASSWORD, bootstrapProperties.getProperty("boost.db.password"))
-            assertEquals("Incorrect boost.db.databaseName found in bootstrap.properties.", DB_NAME, bootstrapProperties.getProperty("boost.db.databaseName"))
+            assertEquals("Incorrect boost_db_user found in bootstrap.properties.", DB_USER, bootstrapProperties.getProperty("boost_db_user"))
+            assertEquals("Incorrect boost_db_password found in bootstrap.properties.", AES_HASHED_PASSWORD, bootstrapProperties.getProperty("boost_db_password"))
+            assertEquals("Incorrect boost_db_databaseName found in bootstrap.properties.", DB_NAME, bootstrapProperties.getProperty("boost_db_databaseName"))
         } catch (IOException ex) {
             ex.printStackTrace()
         } finally {

--- a/boost-maven/boost-maven-plugin/pom.xml
+++ b/boost-maven/boost-maven-plugin/pom.xml
@@ -95,7 +95,7 @@
                                 <boostRuntime>${boostRuntime}</boostRuntime>
                                 <!-- Explicitly set the boost port to 9000 
                                     for testing purposes across multiple runtimes -->
-                                <boost.http.port>9000</boost.http.port>
+                                <boost_http_port>9000</boost_http_port>
                             </properties>
                         </configuration>
                         <executions>

--- a/boost-maven/boost-maven-plugin/src/it/test-dev-release/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-dev-release/pom.xml
@@ -36,7 +36,7 @@
 					</pomIncludes>
 					<properties>
 						<boostRuntime>${boostRuntime}</boostRuntime>
-						<boost.http.port>${boost.http.port}</boost.http.port>
+						<boost_http_port>${boost_http_port}</boost_http_port>
 					</properties>
 				</configuration>
 				<executions>

--- a/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/release-project/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-dev-release/src/it/release-project/src/test/java/it/EndpointIT.java
@@ -27,7 +27,7 @@ public class EndpointIT {
         String runtime = System.getProperty("boostRuntime");
         org.junit.Assume.assumeTrue("ol".equals(runtime) || "wlp".equals(runtime));
 
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         URL = "http://localhost:" + port + "/population";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-dynamic-update/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-dynamic-update/src/test/java/it/EndpointIT.java
@@ -48,7 +48,7 @@ public class EndpointIT {
         String runtime = System.getProperty("boostRuntime");
         org.junit.Assume.assumeTrue("ol".equals(runtime) || "wlp".equals(runtime));
 
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         URL = "http://localhost:" + port + "/api/hello";
 
         if (System.getProperty("os.name").contains("Windows")) {
@@ -98,8 +98,8 @@ public class EndpointIT {
     }
 
     /*
-     * Execute mvn compile Note the command will be different in Windows,
-     * Linux/MAC and Cygwin. Thus all the
+     * Execute mvn compile Note the command will be different in Windows, Linux/MAC
+     * and Cygwin. Thus all the
      */
     private void mavenCompile() throws IOException {
 
@@ -167,9 +167,8 @@ public class EndpointIT {
     }
 
     /*
-     * get file name path setup correctly for environment. This file will be
-     * edited on the fly by the testcase This is to test loosApplication
-     * function.
+     * get file name path setup correctly for environment. This file will be edited
+     * on the fly by the testcase This is to test loosApplication function.
      */
     private static void setupHelloResources() {
 

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.0/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.0/src/test/java/it/EndpointIT.java
@@ -22,7 +22,7 @@ public class EndpointIT {
 
     @BeforeClass
     public static void init() {
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         URL = "http://localhost:" + port + "/api/hello";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/src/test/java/it/EndpointIT.java
@@ -23,7 +23,7 @@ public class EndpointIT {
 
     @BeforeClass
     public static void init() {
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         URL = "http://localhost:" + port + "/api/hello";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/invoker.properties
@@ -1,4 +1,4 @@
 #Using profiles to configure failsafe to run certain tests
-invoker.goals.1 = clean install -PnoEncoding -Dboost.db.databaseName=myCustomDB -Dboost.db.user=user -Dboost.db.password=password -Dboost.aes.key=test
+invoker.goals.1 = clean install -PnoEncoding -Dboost_db_databaseName=myCustomDB -Dboost_db_user=user -Dboost_db_password=password -Dboost_aes_key=test
 #Running aes hashed password test to see if it rehashes
-invoker.goals.2 = clean install -Paes -Dboost.db.databaseName=myCustomDB -Dboost.db.user=user -Dboost.db.password="{aes}Lz4sLCgwLTs="
+invoker.goals.2 = clean install -Paes -Dboost_db_databaseName=myCustomDB -Dboost_db_user=user -Dboost_db_password="{aes}Lz4sLCgwLTs="

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/src/test/java/it/Db2PasswordAesIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/src/test/java/it/Db2PasswordAesIT.java
@@ -40,13 +40,13 @@ public class Db2PasswordAesIT implements BoostConstants {
     public void checkPropertiesTest() throws Exception {
         String variablesXml = "target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults/variables.xml";
 
-        assertEquals("Incorrect boost.db.user found in server config.", DB_USER,
+        assertEquals("Incorrect boost_db_user found in server config.", DB_USER,
                 LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_USER));
-        
-        assertEquals("Incorrect boost.db.password found in server config.", ENCODED_DB_PASS,
+
+        assertEquals("Incorrect boost_db_password found in server config.", ENCODED_DB_PASS,
                 LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_PASSWORD));
-        
-        assertEquals("Incorrect boost.db.databaseName found in server config.", DB_NAME,
+
+        assertEquals("Incorrect boost_db_databaseName found in server config.", DB_NAME,
                 LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_DATABASE_NAME));
     }
 }

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/src/test/java/it/Db2PropertiesIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/src/test/java/it/Db2PropertiesIT.java
@@ -38,17 +38,17 @@ public class Db2PropertiesIT implements BoostConstants {
 
     @Test
     public void checkPropertiesTest() throws Exception {
-    	String variablesXml = "target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults/variables.xml";
+        String variablesXml = "target/liberty/wlp/usr/servers/defaultServer/configDropins/defaults/variables.xml";
 
-        assertEquals("Incorrect boost.db.user found in generated config.", DB_USER,
-        		LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_USER));
-        
-        assertEquals("Incorrect boost.db.databaseName found in generated config.", DB_NAME,
-        		LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_DATABASE_NAME));
-        
+        assertEquals("Incorrect boost_db_user found in generated config.", DB_USER,
+                LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_USER));
+
+        assertEquals("Incorrect boost_db_databaseName found in generated config.", DB_NAME,
+                LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_DATABASE_NAME));
+
         // AES hashed password changes so we're just going to look for the
         // aes flag.
-        assertTrue("Incorrect boost.db.password found in generated config",
-        		LibertyConfigFileUtils.findVariableInXml(variablesXml, DATASOURCE_PASSWORD).contains(AES_HASHED_PASSWORD_FLAG));
+        assertTrue("Incorrect boost_db_password found in generated config", LibertyConfigFileUtils
+                .findVariableInXml(variablesXml, DATASOURCE_PASSWORD).contains(AES_HASHED_PASSWORD_FLAG));
     }
 }

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/src/test/java/utils/BoostConstants.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc-db2/src/test/java/utils/BoostConstants.java
@@ -13,12 +13,12 @@ package utils;
 
 public interface BoostConstants {
 
-    public static final String DATASOURCE_PREFIX = "boost.db.";
-    public static final String DATASOURCE_DATABASE_NAME = "boost.db.databaseName";
-    public static final String DATASOURCE_SERVER_NAME = "boost.db.serverName";
-    public static final String DATASOURCE_PORT_NUMBER = "boost.db.portNumber";
-    public static final String DATASOURCE_USER = "boost.db.user";
-    public static final String DATASOURCE_PASSWORD = "boost.db.password";
-    public static final String DATASOURCE_CREATE_DATABASE = "boost.db.createDatabase";
-    public static final String DATASOURCE_URL = "boost.db.url";
+    public static final String DATASOURCE_PREFIX = "boost_db_";
+    public static final String DATASOURCE_DATABASE_NAME = "boost_db_databaseName";
+    public static final String DATASOURCE_SERVER_NAME = "boost_db_serverName";
+    public static final String DATASOURCE_PORT_NUMBER = "boost_db_portNumber";
+    public static final String DATASOURCE_USER = "boost_db_user";
+    public static final String DATASOURCE_PASSWORD = "boost_db_password";
+    public static final String DATASOURCE_CREATE_DATABASE = "boost_db_createDatabase";
+    public static final String DATASOURCE_URL = "boost_db_url";
 }

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/invoker.properties
@@ -2,7 +2,7 @@
 invoker.goals.1 = clean install -Pderby
 
 # MySQL - JDBC url
-invoker.goals.2 = clean install -Pmysql -Dboost.db.url=jdbc:mysql://localhost:3306/testdb -Dboost.db.user=mysql -Dboost.db.password=mysql
+invoker.goals.2 = clean install -Pmysql -Dboost_db_url=jdbc:mysql://localhost:3306/testdb -Dboost_db_user=mysql -Dboost_db_password=mysql
 
 # MySQL - separate JDBC properties
-invoker.goals.3 = clean install -Pmysql -Dboost.db.serverName=localhost -Dboost.db.portNumber=3306 -Dboost.db.databaseName=testdb -Dboost.db.user=mysql -Dboost.db.password=mysql
+invoker.goals.3 = clean install -Pmysql -Dboost_db_serverName=localhost -Dboost_db_portNumber=3306 -Dboost_db_databaseName=testdb -Dboost_db_user=mysql -Dboost_db_password=mysql

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/pom.xml
@@ -289,7 +289,7 @@
 						</goals>
 						<configuration>
 							<systemPropertyVariables>
-								<test.port>${boost.http.port}</test.port>
+								<test.port>${boost_http_port}</test.port>
 							</systemPropertyVariables>
 						</configuration>
 					</execution>

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/src/test/java/it/EndpointIT.java
@@ -22,7 +22,7 @@ public class EndpointIT {
 
     @BeforeClass
     public static void init() {
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         URL = "http://localhost:" + port + "/population";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-jdbc/src/test/java/it/HealthCheck.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jdbc/src/test/java/it/HealthCheck.java
@@ -34,7 +34,7 @@ public class HealthCheck {
     @Test
     public void testServlet() throws Exception {
 
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         String urlString = "http://localhost:" + port + "/health";
 
         URL url = new URL(urlString);

--- a/boost-maven/boost-maven-plugin/src/it/test-jpa-2.1/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jpa-2.1/src/test/java/it/EndpointIT.java
@@ -26,7 +26,7 @@ public class EndpointIT {
 
     @BeforeClass
     public static void init() {
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         URL = "http://localhost:" + port;
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-jpa-2.2/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jpa-2.2/src/test/java/it/EndpointIT.java
@@ -26,7 +26,7 @@ public class EndpointIT {
 
     @BeforeClass
     public static void init() {
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         URL = "http://localhost:" + port;
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-health-1.0/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-health-1.0/invoker.properties
@@ -1,2 +1,2 @@
 # User port 9080 to match mpConfig property
-invoker.goals.1 = clean install -Dboost.http.port=9080
+invoker.goals.1 = clean install -Dboost_http_port=9080

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-health-1.0/src/test/java/it/io/openliberty/guides/health/HealthTestUtil.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-health-1.0/src/test/java/it/io/openliberty/guides/health/HealthTestUtil.java
@@ -37,7 +37,7 @@ public class HealthTestUtil {
     public static final String INV_MAINTENANCE_TRUE = "io_openliberty_guides_inventory_inMaintenance\":true";
 
     static {
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         baseUrl = "http://localhost:" + port;
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-health-2.0/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-health-2.0/invoker.properties
@@ -1,2 +1,2 @@
 # User port 9080 to match mpConfig property
-invoker.goals.1 = clean install -Dboost.http.port=9080
+invoker.goals.1 = clean install -Dboost_http_port=9080

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-health-2.0/src/test/java/it/io/openliberty/guides/health/HealthTestUtil.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-health-2.0/src/test/java/it/io/openliberty/guides/health/HealthTestUtil.java
@@ -37,7 +37,7 @@ public class HealthTestUtil {
     public static final String INV_MAINTENANCE_TRUE = "io_openliberty_guides_inventory_inMaintenance\":true";
 
     static {
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         baseUrl = "http://localhost:" + port;
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-jwt-1.1/src/test/java/it/jwt/JwtIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-jwt-1.1/src/test/java/it/jwt/JwtIT.java
@@ -44,7 +44,7 @@ public class JwtIT {
         // until the failures are addressed.
         String runtime = System.getProperty("boostRuntime");
         org.junit.Assume.assumeTrue("ol".equals(runtime) || "wlp".equals(runtime));
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         baseUrl = "http://localhost:" + port;
 
         JwtVerifier jwtvf = new JwtVerifier();

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-metrics-1.1/src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-metrics-1.1/src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java
@@ -28,7 +28,7 @@ public class MetricsIT {
 
     @BeforeClass
     public static void oneTimeSetup() {
-        httpPort = System.getProperty("boost.http.port");
+        httpPort = System.getProperty("boost_http_port");
         baseHttpUrl = "http://localhost:" + httpPort + "/";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-metrics-2.0/src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-metrics-2.0/src/test/java/it/io/openliberty/guides/metrics/MetricsIT.java
@@ -28,7 +28,7 @@ public class MetricsIT {
 
     @BeforeClass
     public static void oneTimeSetup() {
-        httpPort = System.getProperty("boost.http.port");
+        httpPort = System.getProperty("boost_http_port");
         baseHttpUrl = "http://localhost:" + httpPort + "/";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/invoker.properties
@@ -1,2 +1,2 @@
 # User port 9000 to match mpConfig property
-invoker.goals.1 = clean install -Dboost.http.port=9000
+invoker.goals.1 = clean install -Dboost_http_port=9000

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/src/test/java/it/io/openliberty/guides/client/RestClientIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/src/test/java/it/io/openliberty/guides/client/RestClientIT.java
@@ -38,7 +38,7 @@ public class RestClientIT {
     @BeforeClass
     public static void oneTimeSetup() {
         // port = System.getProperty("liberty.test.port");
-        port = System.getProperty("boost.http.port");
+        port = System.getProperty("boost_http_port");
         // port = "9000";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -39,7 +39,7 @@ public class InventoryEndpointIT {
     @BeforeClass
     public static void oneTimeSetup() {
         // port = System.getProperty("liberty.test.port");
-        port = System.getProperty("boost.http.port");
+        port = System.getProperty("boost_http_port");
         // port = "9000";
 
         baseUrl = "http://localhost:" + port + "/";

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.1/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -26,7 +26,7 @@ public class SystemEndpointIT {
     @Test
     public void testGetProperties() {
         // String port = System.getProperty("liberty.test.port");
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         // String port = "9000";
         String url = "http://localhost:" + port + "/";
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/invoker.properties
@@ -1,2 +1,2 @@
 # User port 9000 to match mpConfig property
-invoker.goals.1 = clean install -Dboost.http.port=9000
+invoker.goals.1 = clean install -Dboost_http_port=9000

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/src/test/java/it/io/openliberty/guides/client/RestClientIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/src/test/java/it/io/openliberty/guides/client/RestClientIT.java
@@ -38,7 +38,7 @@ public class RestClientIT {
     @BeforeClass
     public static void oneTimeSetup() {
         // port = System.getProperty("liberty.test.port");
-        port = System.getProperty("boost.http.port");
+        port = System.getProperty("boost_http_port");
         // port = "9000";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -39,7 +39,7 @@ public class InventoryEndpointIT {
     @BeforeClass
     public static void oneTimeSetup() {
         // port = System.getProperty("liberty.test.port");
-        port = System.getProperty("boost.http.port");
+        port = System.getProperty("boost_http_port");
         // port = "9000";
 
         baseUrl = "http://localhost:" + port + "/";

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.2/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -26,7 +26,7 @@ public class SystemEndpointIT {
     @Test
     public void testGetProperties() {
         // String port = System.getProperty("liberty.test.port");
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         // String port = "9000";
         String url = "http://localhost:" + port + "/";
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/invoker.properties
@@ -1,2 +1,2 @@
 # User port 9000 to match mpConfig property
-invoker.goals.1 = clean install -Dboost.http.port=9000
+invoker.goals.1 = clean install -Dboost_http_port=9000

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/src/test/java/it/io/openliberty/guides/client/RestClientIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/src/test/java/it/io/openliberty/guides/client/RestClientIT.java
@@ -38,7 +38,7 @@ public class RestClientIT {
     @BeforeClass
     public static void oneTimeSetup() {
         // port = System.getProperty("liberty.test.port");
-        port = System.getProperty("boost.http.port");
+        port = System.getProperty("boost_http_port");
         // port = "9000";
     }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointIT.java
@@ -39,7 +39,7 @@ public class InventoryEndpointIT {
     @BeforeClass
     public static void oneTimeSetup() {
         // port = System.getProperty("liberty.test.port");
-        port = System.getProperty("boost.http.port");
+        port = System.getProperty("boost_http_port");
         // port = "9000";
 
         baseUrl = "http://localhost:" + port + "/";

--- a/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-mp-rest-client-1.3/src/test/java/it/io/openliberty/guides/system/SystemEndpointIT.java
@@ -26,7 +26,7 @@ public class SystemEndpointIT {
     @Test
     public void testGetProperties() {
         // String port = System.getProperty("liberty.test.port");
-        String port = System.getProperty("boost.http.port");
+        String port = System.getProperty("boost_http_port");
         // String port = "9000";
         String url = "http://localhost:" + port + "/";
 

--- a/boost-maven/boost-runtimes/runtime-openliberty/src/main/java/boost/runtimes/openliberty/LibertyRuntime.java
+++ b/boost-maven/boost-runtimes/runtime-openliberty/src/main/java/boost/runtimes/openliberty/LibertyRuntime.java
@@ -127,8 +127,8 @@ public class LibertyRuntime implements RuntimeI {
     }
 
     /**
-     * Get all booster dependencies and invoke the maven-dependency-plugin to
-     * copy them to the Liberty server.
+     * Get all booster dependencies and invoke the maven-dependency-plugin to copy
+     * them to the Liberty server.
      * 
      * @throws MojoExecutionException
      *
@@ -259,6 +259,7 @@ public class LibertyRuntime implements RuntimeI {
      * Invoke the liberty-maven-plugin to run the install-app goal.
      */
     private void installApp(String installAppPackagesVal) throws MojoExecutionException {
+
         Element deployPackages = element(name("deployPackages"), installAppPackagesVal);
         Element serverNameElement = element(name("serverName"), serverName);
 
@@ -275,16 +276,14 @@ public class LibertyRuntime implements RuntimeI {
     }
 
     /**
-     * Invoke the liberty-maven-plugin to package the server into a runnable
-     * Liberty JAR
+     * Invoke the liberty-maven-plugin to package the server into a runnable Liberty
+     * JAR
      */
     private void createUberJar() throws MojoExecutionException {
         executeMojo(getPlugin(), goal("package"),
-                    configuration(element(name("isInstall"), "false"),
-                        element(name("include"), "minify"),
+                configuration(element(name("isInstall"), "false"), element(name("include"), "minify"),
                         element(name("outputDirectory"), "target/liberty-alt-output-dir"),
-                        element(name("packageType"), "jar"),
-                        element(name("serverName"), serverName)),
+                        element(name("packageType"), "jar"), element(name("serverName"), serverName)),
                 env);
     }
 

--- a/boost-maven/boost-runtimes/runtime-tomee/src/main/java/boost/runtimes/tomee/TomeeServerConfigGenerator.java
+++ b/boost-maven/boost-runtimes/runtime-tomee/src/main/java/boost/runtimes/tomee/TomeeServerConfigGenerator.java
@@ -162,7 +162,7 @@ public class TomeeServerConfigGenerator {
         StreamResult result = new StreamResult(serverXml);
         transformer.transform(source, result);
 
-        // Set boost.http.port in catalina.properties
+        // Set boost_http_port in catalina.properties
         addCatalinaProperty(BoostProperties.ENDPOINT_HTTP_PORT, httpPort);
     }
 
@@ -204,7 +204,7 @@ public class TomeeServerConfigGenerator {
         StreamResult result = new StreamResult(serverXml);
         transformer.transform(source, result);
 
-        // Set boost.http.port in catalina.properties
+        // Set boost_http_port in catalina.properties
         addCatalinaProperty(BoostProperties.ENDPOINT_HOST, hostname);
     }
 


### PR DESCRIPTION
switch the boost property names from using a '.' separator to using a '_' char